### PR TITLE
Refactoring around how store context is handled

### DIFF
--- a/app/code/community/VinaiKopp/Api2SessionAuthAdapter/Helper/Frontend/Session.php
+++ b/app/code/community/VinaiKopp/Api2SessionAuthAdapter/Helper/Frontend/Session.php
@@ -1,12 +1,8 @@
 <?php
 
 
-class VinaiKopp_Api2SessionAuthAdapter_Helper_Frontend_Session
-    extends Mage_Core_Helper_Abstract
+class VinaiKopp_Api2SessionAuthAdapter_Helper_Frontend_Session extends Mage_Core_Helper_Abstract
 {
-    // See Mage_Core_Controller_Front_Action::SESSION_NAMESPACE
-    const SESSION_NAMESPACE = 'frontend';
-    
     /**
      * @var Mage_Core_Model_Session
      */
@@ -31,7 +27,7 @@ class VinaiKopp_Api2SessionAuthAdapter_Helper_Frontend_Session
             // @codeCoverageIgnoreStart
             $this->_coreSession = Mage::getSingleton(
                 'core/session',
-                array('name' => self::SESSION_NAMESPACE)
+                array('name' => Mage_Core_Controller_Front_Action::SESSION_NAMESPACE)
             );
         }
         // @codeCoverageIgnoreEnd
@@ -93,41 +89,26 @@ class VinaiKopp_Api2SessionAuthAdapter_Helper_Frontend_Session
      *
      * @return bool
      */
-    public function hasFrontendSession()
+    public function hasFrontendSessionCookie()
     {
-        return (bool)$this->getCookie()->get(self::SESSION_NAMESPACE);
-    }
-
-    /**
-     * @return string
-     */
-    public function getFrontendStoreCode()
-    {
-        $store = $this->getCookie()->get('store');
-        if (! $store) {
-            $store = $this->getApp()->getDefaultStoreView()->getCode();
-        }
-        return $store;
+        return (bool)$this->getCookie()->get(Mage_Core_Controller_Front_Action::SESSION_NAMESPACE);
     }
 
     /**
      * Start the frontend session
+     *
+     * @return $this
+     *
+     * @throws Mage_Api2_Exception
      */
     public function startFrontendSession()
     {
-        $this->getCoreSession()->start();
-        return $this;
-    }
+        if($this->getApp()->getStore()->isAdmin()) {
+            throw new Mage_Api2_Exception('Access denied', Mage_Api2_Model_Server::HTTP_FORBIDDEN);
+        }
 
-    /**
-     * Set the current store
-     * 
-     * @return $this
-     */
-    public function initFrontendStore()
-    {
-        $store = $this->getFrontendStoreCode();
-        $this->getApp()->setCurrentStore($store);
+        $this->getCoreSession()->start();
+
         return $this;
     }
-} 
+}

--- a/app/code/community/VinaiKopp/Api2SessionAuthAdapter/Model/Auth/Adapter/Session.php
+++ b/app/code/community/VinaiKopp/Api2SessionAuthAdapter/Model/Auth/Adapter/Session.php
@@ -84,11 +84,8 @@ class VinaiKopp_Api2SessionAuthAdapter_Model_Auth_Adapter_Session
     public function isApplicableToRequest(Mage_Api2_Model_Request $request)
     {
         $helper = $this->getHelper();
-        if ($helper->hasFrontendSession()) {
-
-            $helper->initFrontendStore();
+        if ($helper->hasFrontendSessionCookie()) {
             $helper->startFrontendSession();
-            
             return $this->getCustomerSession()->isLoggedIn();
         }
         return false;

--- a/app/etc/modules/VinaiKopp_Api2SessionAuthAdapter.xml
+++ b/app/etc/modules/VinaiKopp_Api2SessionAuthAdapter.xml
@@ -5,6 +5,8 @@
             <active>true</active>
             <codePool>community</codePool>
             <depends>
+                <Mage_Core/>
+                <Mage_Customer/>
                 <Mage_Api2/>
             </depends>
         </VinaiKopp_Api2SessionAuthAdapter>

--- a/tests/integration/VinaiKopp/Api2SessionAuthAdapter/Helper/Frontend/SessionTest.php
+++ b/tests/integration/VinaiKopp/Api2SessionAuthAdapter/Helper/Frontend/SessionTest.php
@@ -144,14 +144,14 @@ class VinaiKopp_Api2SessionAuthAdapter_Helper_Frontend_SessionTest extends Vinai
     /**
      * @test
      */
-    public function itHasAMethodHasFrontendSession()
+    public function itHasAMethodHasFrontendSessionCookie()
     {
-        $this->assertTrue(is_callable(array($this->_class, 'hasFrontendSession')));
+        $this->assertTrue(is_callable(array($this->_class, 'hasFrontendSessionCookie')));
     }
 
     /**
      * @test
-     * @depends itHasAMethodHasFrontendSession
+     * @depends itHasAMethodHasFrontendSessionCookie
      */
     public function itReturnsTrueWhenAFrontendCookieIsPresent()
     {
@@ -159,12 +159,12 @@ class VinaiKopp_Api2SessionAuthAdapter_Helper_Frontend_SessionTest extends Vinai
 
         $model = $this->_getInstance($mockCookie);
 
-        $this->assertTrue($model->hasFrontendSession());
+        $this->assertTrue($model->hasFrontendSessionCookie());
     }
 
     /**
      * @test
-     * @depends itHasAMethodHasFrontendSession
+     * @depends itHasAMethodHasFrontendSessionCookie
      */
     public function itReturnsFalseWhenNoFrontendCookieIsPresent()
     {
@@ -173,41 +173,7 @@ class VinaiKopp_Api2SessionAuthAdapter_Helper_Frontend_SessionTest extends Vinai
         /** @var VinaiKopp_Api2SessionAuthAdapter_Helper_Frontend_Session $model */
         $model = new $this->_class($mockCookie);
 
-        $this->assertFalse($model->hasFrontendSession());
-    }
-
-    /**
-     * @test
-     */
-    public function itHasAMethodGetFrontendStoreCode()
-    {
-        $this->assertTrue(is_callable(array($this->_class, 'getFrontendStoreCode')));
-    }
-
-    /**
-     * @test
-     * @depends itHasAMethodGetFrontendStoreCode
-     */
-    public function itReturnsTheStoreCookieValueIfSet()
-    {
-        $mockCookie = $this->_getMockCookie(false, 'test');
-
-        $model = $this->_getInstance($mockCookie);
-        $this->assertEquals('test', $model->getFrontendStoreCode());
-    }
-
-    /**
-     * @test
-     * @depends itHasAMethodGetFrontendStoreCode
-     */
-    public function itReturnsTheDefaultStoreIfNoStoreCookieIsSet()
-    {
-        $mockCookie = $this->_getMockCookie();
-
-        $expected = Mage::app()->getDefaultStoreView()->getCode();
-
-        $model = $this->_getInstance($mockCookie);
-        $this->assertEquals($expected, $model->getFrontendStoreCode());
+        $this->assertFalse($model->hasFrontendSessionCookie());
     }
 
     /**
@@ -231,57 +197,4 @@ class VinaiKopp_Api2SessionAuthAdapter_Helper_Frontend_SessionTest extends Vinai
         $model = $this->_getInstance(null, $mockSession);
         $model->startFrontendSession();
     }
-
-    /**
-     * @test
-     * @depends testClassExists
-     */
-    public function itHasAMethodInitFrontendStore()
-    {
-        $this->assertTrue(is_callable(array($this->_class, 'initFrontendStore')));
-    }
-
-    /**
-     * @test
-     * @depends itHasAMethodInitFrontendStore
-     */
-    public function itCallsSetCurrentStoreFromCookieOnTheApp()
-    {
-        $mockCookie = $this->_getMockCookie(null, 'test'); // test store code
-        $model = $this->_getInstance($mockCookie);
-        $mockApp = $this->getMockBuilder('Mage_Core_Model_App')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $mockApp->expects($this->once())
-            ->method('setCurrentStore')
-            ->with('test');
-        $model->setApp($mockApp);
-        $model->initFrontendStore();
-    }
-
-    /**
-     * @test
-     * @depends itHasAMethodInitFrontendStore
-     */
-    public function itCallsSetCurrentStoreFromDefaultOnTheApp()
-    {
-        $model = $this->_getInstance();
-        
-        $mockStore = $this->getMock('Mage_Core_Model_Store');
-        $mockStore->expects($this->once())
-            ->method('getCode')
-            ->will($this->returnValue('test'));
-            
-        $mockApp = $this->getMockBuilder('Mage_Core_Model_App')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $mockApp->expects($this->once())
-            ->method('getDefaultStoreView')
-            ->will($this->returnValue($mockStore));
-        $mockApp->expects($this->once())
-            ->method('setCurrentStore')
-            ->with('test');
-        $model->setApp($mockApp);
-        $model->initFrontendStore();
-    }
-} 
+}


### PR DESCRIPTION
The store code being pulled out of a cookie was already happening in the
app init method and not needed. Any time the store code was in the cookie
it was basically a noop. This code was removed and now instead the startFrontendSession
method will toss an exception (403 HTTP code) if you are in an admin store context.

This change has the benefit of respecting what Magento has already set the store to without needing special checks.

The session login module has been updated to handle this exception in an intelligent manner
by not handling it and just re-throwing it so the API handler get return a proper 403 response.
