### PR TITLE
Refactor the adapter to init frontend sessions

### DIFF
--- a/app/code/community/VinaiKopp/Api2SessionAuthAdapter/Model/Auth/Adapter/Session.php
+++ b/app/code/community/VinaiKopp/Api2SessionAuthAdapter/Model/Auth/Adapter/Session.php
@@ -33,7 +33,7 @@ class VinaiKopp_Api2SessionAuthAdapter_Model_Auth_Adapter_Session
             $this->_customerSession = $customerSession;
         }
     }
-    
+
     public function getHelper()
     {
         if (!$this->_helper) {
@@ -84,10 +84,16 @@ class VinaiKopp_Api2SessionAuthAdapter_Model_Auth_Adapter_Session
     public function isApplicableToRequest(Mage_Api2_Model_Request $request)
     {
         $helper = $this->getHelper();
-        if ($helper->hasFrontendSessionCookie()) {
-            $helper->startFrontendSession();
-            return $this->getCustomerSession()->isLoggedIn();
+
+        // This auth adapter is for frontend use only
+        if ($helper->getApp()->getStore()->isAdmin()) {
+            return false;
         }
-        return false;
+
+        // Ensure frontend sessions are initialized using the proper cookie name
+        $helper->startFrontendSession();
+
+        // We are only applicable if the customer is logged in already
+        return $this->getCustomerSession()->isLoggedIn();
     }
 }


### PR DESCRIPTION
The previous behaviour was to only init the session if the correct cookie was found.
This worked fine for logged in customers, but guest customers had problems.
If you used the API as a guest customer with NO SESSION, then a session would be created
without the proper session name. This resulted in a lost session once you visited the site.

The new behaviour will always initialize a frontend session for non-admin store contexts.
This results in a proper session name for guest users.
