### PR TITLE
Init customer session correctly

### DIFF
--- a/app/code/community/VinaiKopp/Api2SessionAuthAdapter/Helper/Frontend/Session.php
+++ b/app/code/community/VinaiKopp/Api2SessionAuthAdapter/Helper/Frontend/Session.php
@@ -103,10 +103,6 @@ class VinaiKopp_Api2SessionAuthAdapter_Helper_Frontend_Session extends Mage_Core
      */
     public function startFrontendSession()
     {
-        if($this->getApp()->getStore()->isAdmin()) {
-            throw new Mage_Api2_Exception('Access denied', Mage_Api2_Model_Server::HTTP_FORBIDDEN);
-        }
-
         $this->getCoreSession()->start();
 
         return $this;

--- a/app/code/community/VinaiKopp/Api2SessionAuthAdapter/Model/Auth/Adapter/Session.php
+++ b/app/code/community/VinaiKopp/Api2SessionAuthAdapter/Model/Auth/Adapter/Session.php
@@ -51,7 +51,13 @@ class VinaiKopp_Api2SessionAuthAdapter_Model_Auth_Adapter_Session
     {
         if (!$this->_customerSession) {
             // @codeCoverageIgnoreStart
+            // Temporarily choose a suitable frontend store
+            $oldStore = $this->getHelper()->getApp()->getStore()->getId();
+            $this->getHelper()->getApp()->initSpecified(
+                @$_SERVER['MAGE_RUN_CODE'] ?: '',
+                @$_SERVER['MAGE_RUN_TYPE'] ?: 'store');
             $this->_customerSession = Mage::getSingleton('customer/session');
+            $this->getHelper()->getApp()->setCurrentStore($oldStore);
         }
         // @codeCoverageIgnoreEnd
         return $this->_customerSession;

--- a/app/code/community/VinaiKopp/Api2SessionAuthAdapter/Model/Auth/Adapter/Session.php
+++ b/app/code/community/VinaiKopp/Api2SessionAuthAdapter/Model/Auth/Adapter/Session.php
@@ -85,11 +85,6 @@ class VinaiKopp_Api2SessionAuthAdapter_Model_Auth_Adapter_Session
     {
         $helper = $this->getHelper();
 
-        // This auth adapter is for frontend use only
-        if ($helper->getApp()->getStore()->isAdmin()) {
-            return false;
-        }
-
         // Ensure frontend sessions are initialized using the proper cookie name
         $helper->startFrontendSession();
 

--- a/app/code/community/VinaiKopp/Api2SessionAuthAdapter/Model/Auth/Adapter/Session.php
+++ b/app/code/community/VinaiKopp/Api2SessionAuthAdapter/Model/Auth/Adapter/Session.php
@@ -67,12 +67,10 @@ class VinaiKopp_Api2SessionAuthAdapter_Model_Auth_Adapter_Session
      */
     public function getUserParams(Mage_Api2_Model_Request $request)
     {
-        $userParamsObj = (object)array('type' => null, 'id' => null);
-        if ($this->isApplicableToRequest($request)) {
-            $userParamsObj->id = $this->getCustomerSession()->getCustomerId();
-            $userParamsObj->type = self::USER_TYPE_CUSTOMER;
-        }
-        return $userParamsObj;
+        return (object)array(
+            'id' => $this->getCustomerSession()->getCustomerId(),
+            'type' => self::USER_TYPE_CUSTOMER
+        );
     }
 
     /**


### PR DESCRIPTION
It is necessary to switch stores before starting a customer session.  I have not tested this against your test framework but if it passes it should fix #4.